### PR TITLE
Add GH action to build/push docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Docker Image
+on:
+    workflow_call:
+
+permissions:
+    contents: read
+
+jobs:
+    build_docker:
+        name: Build and Push Docker image
+        if: github.event.repository.fork == false
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            #- name: Login to DockerHub
+            #  uses: docker/login-action@v2
+            #  with:
+            #    username: ${{ secrets.DOCKER_USERNAME }}
+            #    password: ${{ secrets.DOCKER_PASSWORD }}
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GHCR_TOKEN }}
+
+            - name: Build Docker image
+              uses: docker/build-push-action@v3
+              with:
+                  context: .
+                  # platforms: linux/amd64,linux/arm64
+                  tags: |
+                      ${{ github.event.repository.full_name }}:latest
+                      ghcr.io/${{ github.event.repository.full_name }}:latest
+
+            - name: Check Docker image
+              run: docker run --rm -i -v ${PWD}:/docs ${{ github.event.repository.full_name }} build
+
+            - name: Publish Docker image
+              #env:
+              #    DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+              #    DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+              run: docker push --all-tags ghcr.io/${{ github.event.repository.full_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
               uses: docker/login-action@v2
               with:
                   registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GHCR_TOKEN }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build Docker image
               uses: docker/build-push-action@v3


### PR DESCRIPTION
Adds a simple GH Action to build and push the docker image to GitHub Container Registry (GHCR). This does not yet contemplate versioning (i.e., the image is always `:latest`).

This leaves in some groundwork for DockerHub (future endeavor).