### PR TITLE
Fixes images to only refer to ghcr

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -37,7 +37,6 @@ jobs:
           SEMVER: type=semver,value=${{ github.event.release.tag_name }}
         with:
           images: |
-            ${{ github.event.repository.full_name }}
             ghcr.io/${{ github.event.repository.full_name }}
           tags: |
             nightly

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -35,7 +35,6 @@ jobs:
           SEMVER: type=semver,value=${{ github.event.release.tag_name }}
         with:
           images: |
-            ${{ github.event.repository.full_name }}
             ghcr.io/${{ github.event.repository.full_name }}
           tags: |
             ${{ env.SEMVER }},pattern={{version}}


### PR DESCRIPTION
Dockerhub is not yet used. This removes the non-prefixed so that we should only be publishing to GHCR.